### PR TITLE
Use require instead of autoload

### DIFF
--- a/lib/branch_io.rb
+++ b/lib/branch_io.rb
@@ -1,10 +1,8 @@
 require "branch_io/version"
+require "branch_io/client"
+require "branch_io/link_properties"
 
 module BranchIO
-
-  autoload :Client, "branch_io/client"
-  autoload :LinkProperties, "branch_io/link_properties"
-
   # Default client helper methods: delegate unknown calls to a new Client instance w/ default constructor params
 
   def self.method_missing(name, *args, &block)


### PR DESCRIPTION
Using `autoload :Client` etc was working fine for me locally, however, I would get a `NameError` when trying to run in Production, and a `LoadError: cannot load such file -- branch_io` when trying to require the file.

I was able to fix this issue by using `require` instead of autoload.

P.S - Thanks for the Gem, does the job quite nicely!