### PR TITLE
Add delete API call

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ end
 _The only difference between `#links` and `#links!` is that the latter version will
 raise a new `BranchIO::ErrorApiCallFailed` exception in case of an error._
 
-### `Client#link_info` and `Client#link_info!`: Registers a [new deep linking URL](https://github.com/BranchMetrics/branch-deep-linking-public-api#creating-a-deep-linking-url)
+### `Client#link_info` and `Client#link_info!`: Returns information about a [deep linking URL](https://github.com/BranchMetrics/branch-deep-linking-public-api#creating-a-deep-linking-url)
 
 **BEWARE: this method requires the BRANCH_SECRET to be defined**
 
@@ -159,7 +159,7 @@ end
 **The only difference between `#link_info` and `#link_info!` is that the latter version will
 raise a new `BranchIO::ErrorApiCallFailed` exception in case of an error.**
 
-### `Client#update_link` and `Client#update_link!`: Registers a [new deep linking URL](https://github.com/BranchMetrics/branch-deep-linking-public-api#creating-a-deep-linking-url)
+### `Client#update_link` and `Client#update_link!`: Updates a [deep linking URL](https://github.com/BranchMetrics/branch-deep-linking-public-api#creating-a-deep-linking-url)
 
 **BEWARE: this method requires the BRANCH_SECRET to be defined**
 
@@ -179,6 +179,27 @@ end
 ```
 
 **The only difference between `#update_link` and `#update_link!` is that the latter version will
+raise a new `BranchIO::ErrorApiCallFailed` exception in case of an error.**
+
+### `Client#delete_link` and `Client#delete_link!`: Deletes a [deep linking URL](https://github.com/BranchMetrics/branch-deep-linking-public-api#creating-a-deep-linking-url)
+
+**BEWARE: this method requires the BRANCH_SECRET to be defined**
+
+This method deletes an existing link and returns the URL and deletion confirmation.
+
+```ruby
+# Call the service
+res = client.delete_link("https://...")
+
+# Inspect the server response
+if res.success?
+  puts "Successfully deleted link: #{res.link_deleted.to_json['url']}"
+else
+  puts "Error updating link info: #{res.error}"
+end
+```
+
+**The only difference between `#delete_link` and `#delete_link!` is that the latter version will
 raise a new `BranchIO::ErrorApiCallFailed` exception in case of an error.**
 
 ## Development

--- a/lib/branch_io/client.rb
+++ b/lib/branch_io/client.rb
@@ -40,6 +40,11 @@ module BranchIO
       self.class.put(url, body: body, headers: default_headers)
     end
 
+    def delete(url, data = {})
+      body = data.to_json
+      self.class.delete(url, body: body, headers: default_headers)
+    end
+
     private
 
     def ensure_branch_secret_defined!

--- a/lib/branch_io/client/links.rb
+++ b/lib/branch_io/client/links.rb
@@ -115,6 +115,36 @@ module BranchIO
           ErrorResponse.new(raw_response)
         end
       end
+
+      def delete_link!(url)
+        res = delete_link(url)
+        res.validate!
+        res
+      end
+
+      def delete_link(url)
+        ensure_branch_secret_defined!
+
+        # Build the request URL
+        encoded_url = URI.encode_www_form_component(url)
+        delete_url = "#{LINK_PATH}?url=#{encoded_url}"
+
+        # Build the request body
+        delete_json = {
+          branch_key: self.branch_key,
+          branch_secret: self.branch_secret
+        }
+
+        # Call branch.io public API
+        raw_response = self.delete(delete_url, delete_json)
+
+        # Wrap the result in a Response
+        if raw_response.success?
+          LinkDeletedResponse.new(raw_response)
+        else
+          ErrorResponse.new(raw_response)
+        end
+      end
     end
   end
 end

--- a/lib/branch_io/client/response.rb
+++ b/lib/branch_io/client/response.rb
@@ -107,5 +107,15 @@ module BranchIO
         @link_properties ||= BranchIO::LinkProperties.new(json)
       end
     end
+
+    class LinkDeletedResponse < Response
+      def success?
+        json["deleted"] == true
+      end
+
+      def url
+        json["url"]
+      end
+    end
   end
 end

--- a/spec/cassettes/branch-io.yml
+++ b/spec/cassettes/branch-io.yml
@@ -563,4 +563,129 @@ http_interactions:
       string: '{"channel":"retest","tags":["test","test-update"],"data":{"$one_time_use":false,"~channel":"retest","~creation_source":0,"~id":"279236445598774158","~tags":["test","test-update"],"url":"https://ENV.test-app.link/LINK9xxx"},"type":0,"alias":null}'
     http_version: 
   recorded_at: Wed, 06 Jul 2016 13:56:24 GMT
+- request:
+    method: post
+    uri: https://api.branch.io/v1/url
+    body:
+      encoding: UTF-8
+      string: '{"sdk":"api","branch_key":"<BRANCH_KEY>","tags":["test","test-delete"],"channel":"code","feature":"test"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '47'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Date:
+      - Tue, 07 Jan 2020 00:19:29 GMT
+      Server:
+      - openresty/1.13.6.2
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 a390f799acc33be35de7bc42ed295f39.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - MIA3-C1
+      X-Amz-Cf-Id:
+      - MjPhIu8mM4TUAvusrRgKNvPRi47BLdrlENZMScmDhJ6Y-VTOqgYlfA==
+    body:
+      encoding: UTF-8
+      string: '{"url":"https://uym7.test-app.link/9PgLOiWA22"}'
+    http_version: 
+  recorded_at: Tue, 07 Jan 2020 00:19:29 GMT
+- request:
+    method: delete
+    uri: https://api.branch.io/v1/url?url=https://uym7.test-app.link/9PgLOiWA22
+    body:
+      encoding: UTF-8
+      string: '{"branch_key":"<BRANCH_KEY>","branch_secret":"<BRANCH_SECRET>"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '62'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Date:
+      - Tue, 07 Jan 2020 00:19:29 GMT
+      Server:
+      - openresty/1.13.6.2
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 517d2577302def91b3dd63d535e63fd2.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - MIA3-C1
+      X-Amz-Cf-Id:
+      - OgAnAB3Xj0f3J4IFC3Aen-RWrqbNCAIwGkaVYHBEmWpby09RtY3iIg==
+    body:
+      encoding: UTF-8
+      string: '{"url":"https://uym7.test-app.link/9PgLOiWA22","deleted":true}'
+    http_version: 
+  recorded_at: Tue, 07 Jan 2020 00:19:30 GMT
+- request:
+    method: get
+    uri: https://api.branch.io/v1/url?branch_key=<BRANCH_KEY>&url=https://uym7.test-app.link/9PgLOiWA22
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '313'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Date:
+      - Tue, 07 Jan 2020 00:19:30 GMT
+      Server:
+      - openresty/1.13.6.2
+      Vary:
+      - Accept-Encoding
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 786adf19b53b584c0a277661acb7690d.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - MIA3-C1
+      X-Amz-Cf-Id:
+      - A9hXMo1ggP1JVlAZESVWRf6PHAPOkNEIy9D5_oGvch3fOsmItoOOmw==
+    body:
+      encoding: UTF-8
+      string: '{"data":{"+url":"https://uym7.test-app.link/9PgLOiWA22","~tags":["test","test-delete"],"~creation_source":0,"~id":"742887335519845531","$one_time_use":false,"~channel":"code","~feature":"test","url":"https://uym7.test-app.link/9PgLOiWA22"},"type":0,"tags":["test","test-delete"],"feature":"test","channel":"code"}'
+    http_version: 
+  recorded_at: Tue, 07 Jan 2020 00:19:30 GMT
 recorded_with: VCR 3.0.3

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -208,5 +208,36 @@ describe BranchIO::Client do
         expect(props.channel).to eq("retest")
       end
     end
+
+    describe "#delete_link!" do
+      let!(:url) { client.link(channel: "code", feature: "test", tags: ["test", "test-delete"]).url }
+
+      it "calls #delete_link" do
+        res = double(validate!: true)
+        expect(client).to receive(:delete_link).and_return(res)
+        client.delete_link!(url)
+      end
+    end
+
+    describe "#delete_link" do
+      let!(:url) { client.link(channel: "code", feature: "test", tags: ["test", "test-delete"]).url }
+
+      it "succeeds" do
+        expect(
+          client.delete_link(url)
+        ).to be_success
+      end
+
+      it "deletes the link from the server" do
+        pending unless ENV["BRANCH_KEY"]
+
+        # Delete the link
+        res = client.delete_link(url)
+
+        # It should be successful
+        expect(res).to be_kind_of(BranchIO::Client::LinkDeletedResponse)
+        expect(res.url).not_to be_nil
+      end
+    end
   end # /Client
 end


### PR DESCRIPTION
* Adds `delete_link` and `delete_link!` methods for Branch API
* Adds `delete` verb to client class
* Adds `LinkDeletedResponse` response wrapper
* Includes spec coverage
* Fixes/updates README

branch.io has recently added the ability to delete a link via API. This PR adds the delete feature to the gem for all to use.

_I assume maintainers will handle version bump._